### PR TITLE
chore: remove uuid from dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,7 @@ classifiers = [
 ]
 dependencies = [
   "validators>0.28",
-  "typing_extensions>4.12",
-  "uuid==1.30"
+  "typing_extensions>4.12"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Getting an error when using wsgi

<img width="831" alt="image" src="https://github.com/user-attachments/assets/d60aa766-e476-421e-b627-ddf9aff7d6cf">

From this [SO post](https://stackoverflow.com/questions/33612977/how-to-use-uuid-lib-with-mod-wsgi) seems like it's not needed since python 2.5