### PR TITLE
docs: validate

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,17 @@ In its essence, `zon` behaves much like `zod`. If you have used `zod`, you will 
 > [!NOTE]  
 > There are some differences in the public API between `zon` and `zod`. Those mostly stem from the fact that Python does not have type inference like Typescript has. There are other slight deviations between `zon` and `zod`. 
 
+### General
+
+#### Validate
+
+To validate against a schema, use `validator.validate()`
+
+```python
+validator = zon.string()
+validator.validate("Hello World!") # returns 'Hello World!'
+```
+
 ### Basic types
 
 `zon` features most of `zod`'s basic types:

--- a/README.md
+++ b/README.md
@@ -49,8 +49,17 @@ To validate against a schema, use `validator.validate()`
 
 ```python
 validator = zon.string()
-validator.validate("Hello World!") # returns 'Hello World!'
+message = validator.validate("Hello World!") # returns 'Hello World!'
 ```
+
+Alternatively, you may use `validator.safe_validate()`.
+`save_validate` will tell you whether the validation was successful, without throwing an error. Depending on the needs of your project, you can do this to handle exceptions more elegantly.
+
+```python
+validator = zon.string()
+success, message = validator.safe_validate("Hello World!") # returns (True, 'Hello World!')
+```
+
 
 ### Basic types
 


### PR DESCRIPTION
`validate` isn't mentioned at all in the readme, you have to go to the examples to see it.