### PR TITLE
Started preparing 3.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
 ## [Unreleased]
+
+## [3.0.0] - 2025-05-16
 
 ### Changed
 - Updated contribution guidelines.
 - Updated CI workflow to run on Pull Request.
+- Updated README.md to include more information and examples of code usage as well as corrected some old examples.
+- Added contributors to the CONTRIBUTORS file.
+
+### Deleted
+- Removed `uuid` as a dependency.
 
 ### Added
 - Added explanation about chaining API to README.md.
@@ -64,7 +72,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added base source code files for the project.
 - Base `README.md` file.
 
-[unreleased]: https://github.com/Naapperas/zon/compare/v2.0.1...HEAD
+[Unreleased]: https://github.com/Naapperas/zon/compare/v3.0.0...HEAD
+[3.0.0]: https://github.com/Naapperas/zon/compare/v2.0.1...v3.0.0
 [2.0.1]: https://github.com/Naapperas/zon/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/Naapperas/zon/compare/v1.1.0...v2.0.0
 [1.1.0]: https://github.com/Naapperas/zon/compare/v1.0.0...v1.1.0

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,1 +1,3 @@
 Nuno Pereira <nunoafonso2002@gmail.com>
+cachho <admin@ch-webdev.com>
+Almas Akchabayev <>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "zon"
-version = "2.0.0"
+version = "3.0.0"
 authors = [
   { name="Nuno Pereira", email="nunoafonso2002@gmail.com" },
 ]

--- a/zon/__init__.py
+++ b/zon/__init__.py
@@ -6,7 +6,7 @@ Flexible validation powered by Python with the expressiveness of a Zod-like API.
 # Why is this needed even?
 from __future__ import annotations
 
-__version__ = "2.0.0"
+__version__ = "3.0.0"
 __author__ = "Nuno Pereira"
 __email__ = "nunoafonso2002@gmail.com"
 __license__ = "MIT"
@@ -181,7 +181,9 @@ class Zon(ABC):
         )
 
     @final
-    def _validate(self, data: T) -> tuple[Literal[True], T] | tuple[Literal[False], ZonError]:
+    def _validate(
+        self, data: T
+    ) -> tuple[Literal[True], T] | tuple[Literal[False], ZonError]:
         """Validates the supplied data.
 
         Args:


### PR DESCRIPTION
Prepare the `3.0.0` release of `zon`. This is a major version change because a dependency (`uuid`) was removed, potentially breaking client code.